### PR TITLE
修复时间戳校验失败的问题

### DIFF
--- a/src/core/message.cc
+++ b/src/core/message.cc
@@ -20,7 +20,7 @@ void AuthHeader::updateHash(const std::string &password) {
 
 bool AuthHeader::check(const std::string &password) {
     // 检查时间戳
-    if (std::abs(Time::unixTime() - Time::netToHost(this->timestamp)) > 30) {
+    if (std::abs(Time::unixTime() - (int64_t)Time::netToHost(this->timestamp)) > 30) {
         spdlog::warn("Auth header timestamp check failed. timestamp={0}", Time::netToHost(this->timestamp));
         return false;
     }
@@ -59,7 +59,7 @@ void DynamicAddressHeader::updateHash(const std::string &password) {
 
 bool DynamicAddressHeader::check(const std::string &password) {
     // 检查时间戳
-    if (std::abs(Time::unixTime() - Time::netToHost(this->timestamp)) > 30) {
+    if (std::abs(Time::unixTime() - (int64_t)Time::netToHost(this->timestamp)) > 30) {
         spdlog::warn("Dynamic address header timestamp check failed. timestamp={0}", Time::netToHost(this->timestamp));
         return false;
     }


### PR DESCRIPTION
有符号整数和无符号整数运算时默认转换为无符号数,当服务端时间早于
客户端上报的时间时,将产生一个大整数,无法通过时间戳校验,会导致正常
的客户端无法成功连接.

将时间戳强制转换为 64 位有符号数进行比较.