### PR TITLE
调整断连日志

### DIFF
--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -253,12 +253,11 @@ void Server::handleCloseMessage(WebSocketMessage &message) {
     }
 
     if (this->ipWsMap[it->second] == message.conn) {
+        Address address;
+        if (!address.ipUpdate(it->second)) {
+            spdlog::info("client disconnected: {}", address.getIpStr());
+        }
         this->ipWsMap.erase(it->second);
-    }
-
-    Address address;
-    if (!address.ipUpdate(it->second)) {
-        spdlog::info("client disconnected: {}", address.getIpStr());
     }
 
     this->wsIpMap.erase(it);


### PR DESCRIPTION
IP 冲突时,后一个 WebSocket 建立连接后,前一个 WebSocket 连接才断开.
建连的标志是发送了有效的 Auth Message, 断开连接的标志是 WebSocket
断开.此时在日志中的表现是某个 IP 连接后马上断开,因此调整断连日志,
如果前一个连接因为冲突被踢出,就不打印连接断开的日志.