### PR TITLE
只保存有效地址到磁盘

### DIFF
--- a/src/main/linux.cc
+++ b/src/main/linux.cc
@@ -208,7 +208,7 @@ int main(int argc, char *argv[]) {
     server.shutdown();
     client.shutdown();
 
-    if (arguments.mode == "client") {
+    if (!client.getAddress().empty()) {
         saveLatestAddress(arguments.name, client.getAddress());
     }
 


### PR DESCRIPTION
客户端启动过程出现错误时,例如无法与服务端连接,将会有空地址覆盖掉最近
一次使用的地址,下次启动发现上次保留的地址无效,进而申请新地址.