### PR TITLE
调整 TUN 设备名称设置方式

### DIFF
--- a/src/core/client.cc
+++ b/src/core/client.cc
@@ -123,7 +123,7 @@ int Client::startWsThread() {
 }
 
 int Client::startTunThread() {
-    if (this->tun.setName(this->tunName.empty() ? "candy" : "candy-" + this->tunName)) {
+    if (this->tun.setName(this->tunName)) {
         return -1;
     }
     if (this->tun.setAddress(this->localAddress)) {

--- a/src/tun/darwin.cc
+++ b/src/tun/darwin.cc
@@ -23,7 +23,7 @@ namespace {
 class DarwinTun {
 public:
     int setName(const std::string &name) {
-        this->name = name;
+        this->name = name.empty() ? "candy" : "candy-" + name;
         return 0;
     }
 

--- a/src/tun/linux.cc
+++ b/src/tun/linux.cc
@@ -19,7 +19,7 @@ namespace {
 class LinuxTun {
 public:
     int setName(const std::string &name) {
-        this->name = name;
+        this->name = name.empty() ? "candy" : "candy-" + name;
         return 0;
     }
 

--- a/src/tun/windows.cc
+++ b/src/tun/windows.cc
@@ -12,7 +12,7 @@ namespace {
 class WindowsTun {
 public:
     int setName(const std::string &name) {
-        this->name = name;
+        this->name = name.empty() ? "candy" : name;
         return 0;
     }
 


### PR DESCRIPTION
Windows 有专门的字段表示设备类型,不需要在名称中体现,因此将设置名称的细节下放到各系统单独实现.