### PR TITLE
修改配置格式和文件名

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
       run: |
         cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build
         mkdir artifact
-        cp candy.conf artifact
+        cp candy.cfg artifact
         cp build/src/tun/wintun/bin/amd64/wintun.dll artifact
         scripts/search-deps.sh build/src/main/candy.exe artifact
     - name: set release package name

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "program": "${workspaceFolder}/build/src/main/candy",
             "args": [
                 "-c",
-                "candy.conf",
+                "candy.cfg",
                 "--debug"
             ],
             "stopAtEntry": true,
@@ -25,7 +25,7 @@
             "program": "${workspaceFolder}/build/src/main/candy",
             "args": [
                 "-c",
-                "candy.conf",
+                "candy.cfg",
                 "--debug"
             ],
             "stopAtEntry": false,

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ zypper refresh && zypper install candy
 
 ### 接入测试网络
 
-客户端的[默认配置](candy.conf)会连到测试网络 172.16.0.0/16, 并被随机分配一个地址.
+客户端的[默认配置](candy.cfg)会连到测试网络并被随机分配一个地址.
 
 客户端会缓存服务端分配的地址,并在下次启动时优先申请使用这个地址,地址保存在 `/var/lib/candy` 目录下,启动容器服务前需要在 Host 创建一个目录用于映射,否则容器重启丢失数据将导致重新分配地址.
 
@@ -101,7 +101,7 @@ candy --help
 
 ```bash
 # 指定配置文件路径
-candy -c /path/to/candy.conf
+candy -c /path/to/candy.cfg
 ```
 
 #### 服务端

--- a/candy.cfg
+++ b/candy.cfg
@@ -1,56 +1,59 @@
 ############################## Client and Server ##############################
 # [Required] Working mode, "client" or "server"
-mode = "client"
+mode = "client";
 
 # [Required] The address for communication between the client and the server.
 # Server only supports ws and needs to provide wss through an external web
 # service. Client supports ws and wss.
-websocket = "wss://canets.org/demo"
+websocket = "wss://canets.org/demo";
 
 # [Optional] Password used to verify identity
 # Only the hashed content of the password and timestamp is transmitted on the
 # network, and the password cannot be obtained from the message.
-#password = "this is the password"
+#password = "this is the password";
+
+# [Optional] Show debug log
+#debug = false;
 
 ################################# Server Only #################################
 # [Optional] The range of addresses automatically assigned by the server
 # Server address allocation is not enabled by default, and the client needs to
 # configure a static address through tun.
-#dhcp = "172.16.0.0/16"
+#dhcp = "172.16.0.0/16";
 
 ################################# Client Only #################################
 # [Optional] Network interface name
 # Used to differentiate networks when running multiple clients.
-name = "demo"
+name = "demo";
 
 # [Optional] Static address.
 # If dhcp is not configured, tun must be configured. When there is an address
 # conflict, the previous client will be kicked out.
-#tun = "172.16.0.1/16"
+#tun = "172.16.0.1/16";
 
 # [Optional] STUN server address
 # If the STUN server is not configured, P2P will be disabled.
-stun = "stun://stun.canets.org"
+stun = "stun://stun.canets.org";
 
 # [Optional] Active discovery interval
 # Periodically sends broadcasts to try to establish P2P with devices on the
 # network. The default configuration is 0, which means disabled
-discovery = 300
+discovery = 300;
 
 # [Optional] The cost of routing through this machine
 # Use all nodes in the network to establish the link with the lowest latency.
 # This configuration represents the cost of using this node as a relay. The
 # default configuration is 0 which means disabled.
-route = 5
+route = 5;
 
 # [Optional] Local UDP port used for P2P
 # The default configuration is 0, which means it is allocated by the operating
 # system. This configuration can be used when the firewall is strict and can
 # only open specific ports.
-#port = 0
+#port = 0;
 
 # [Optional] The address sent during LAN P2P
 # By default, the LAN address will be automatically detected. When there are
 # multiple network cards, the detected result may not be the optimal result.
 # You can specify it manually.
-#localhost="127.0.0.1"
+#localhost = "127.0.0.1";

--- a/candy.service
+++ b/candy.service
@@ -3,7 +3,7 @@ Description=A reliable, low-latency, and anti-censorship virtual private network
 StartLimitIntervalSec=0
 
 [Service]
-ExecStart=/usr/bin/candy --no-timestamp -c /etc/candy.conf
+ExecStart=/usr/bin/candy --no-timestamp -c /etc/candy.cfg
 Restart=always
 RestartSec=3
 

--- a/candy@.service
+++ b/candy@.service
@@ -3,7 +3,7 @@ Description=A reliable, low-latency, and anti-censorship virtual private network
 StartLimitIntervalSec=0
 
 [Service]
-ExecStart=/usr/bin/candy --no-timestamp -c /etc/candy.d/%i.conf
+ExecStart=/usr/bin/candy --no-timestamp -c /etc/candy.d/%i.cfg
 Restart=always
 RestartSec=3
 

--- a/dockerfile
+++ b/dockerfile
@@ -10,6 +10,6 @@ RUN cd candy && cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --bu
 FROM base AS product
 RUN install -D /dev/null /var/lib/candy/lost
 COPY --from=build /usr/local/bin/candy /usr/bin/candy
-COPY candy.conf /etc/candy.conf
+COPY candy.cfg /etc/candy.cfg
 ENTRYPOINT ["/usr/bin/candy"]
-CMD ["-c", "/etc/candy.conf"]
+CMD ["-c", "/etc/candy.cfg"]

--- a/package/debian/candy.install
+++ b/package/debian/candy.install
@@ -1,2 +1,2 @@
-candy.conf etc
+candy.cfg etc
 candy*.service usr/lib/systemd/system/

--- a/package/openSUSE/candy.spec
+++ b/package/openSUSE/candy.spec
@@ -49,7 +49,7 @@ A reliable, low-latency, and anti-censorship virtual private network
 %install
 %cmake_install
 
-install -D -m 644 candy.conf %{buildroot}/etc/candy.conf
+install -D -m 644 candy.cfg %{buildroot}/etc/candy.cfg
 install -D -m 644 candy.service %{buildroot}%{_unitdir}/candy.service
 install -D -m 644 candy@.service %{buildroot}%{_unitdir}/candy@.service
 
@@ -68,7 +68,7 @@ install -D -m 644 candy@.service %{buildroot}%{_unitdir}/candy@.service
 %files
 %doc README.md
 %{_bindir}/candy
-%config(noreplace) /etc/candy.conf
+%config(noreplace) /etc/candy.cfg
 %{_unitdir}/candy.service
 %{_unitdir}/candy@.service
 


### PR DESCRIPTION
配置文件名调整为 `libconfig` 推荐的 `.cfg`. 为后续添加更复杂的配置(例如数组列表映射)做准备.同时允许在配置文件中开启 `debug` 模式