### PR TITLE
修复静态链接 OpenSSL 导致的崩溃

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(Candy VERSION 6.1.3)
+project(Candy VERSION 6.1.4)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/candy-service/src/main.cc
+++ b/candy-service/src/main.cc
@@ -247,9 +247,11 @@ protected:
             Poco::Net::HTTPServer server(new JSONRequestHandlerFactory, socket, params);
 
             server.start();
-            std::cout << "candy-service bind: " << bindAddress << ":" << port << std::endl;
+            spdlog::info("bind: {}:{}", bindAddress, port);
 
             waitForTerminationRequest();
+            spdlog::info("exit signal detected");
+
             server.stop();
 
             std::lock_guard lock(threadMutex);

--- a/candy/src/peer/message.cc
+++ b/candy/src/peer/message.cc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "peer/message.h"
 #include <string>
 

--- a/candy/src/peer/peer.cc
+++ b/candy/src/peer/peer.cc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "peer/peer.h"
 #include "core/client.h"
 #include "core/message.h"

--- a/cmake/openssl/CMakeLists.txt
+++ b/cmake/openssl/CMakeLists.txt
@@ -8,11 +8,13 @@ include(ExternalProject)
 ExternalProject_Add(
     openssl
     PREFIX                      ${CMAKE_CURRENT_BINARY_DIR}/openssl
-    URL                         https://www.openssl.org/source/openssl-3.4.0.tar.gz
+    URL                         https://www.openssl.org/source/openssl-3.5.4.tar.gz
     LOG_BUILD                   ON
     BUILD_IN_SOURCE             YES
+    CONFIGURE_COMMAND 
+        COMMAND sed -i "s/disable('static', 'pic', 'threads')/disable('static', 'pic')/" Configure
+        COMMAND ./config --release no-unit-test no-shared ${TARGET_OPENSSL} CFLAGS=$ENV{CFLAGS} LDFLAGS=$ENV{LDFLAGS}
     BUILD_COMMAND               ""
-    CONFIGURE_COMMAND           ./config --release no-unit-test no-shared ${TARGET_OPENSSL} CFLAGS=$ENV{CFLAGS} LDFLAGS=$ENV{LDFLAGS}
     INSTALL_COMMAND             ""
     TEST_COMMAND                ""
 )

--- a/scripts/build-standalone.sh
+++ b/scripts/build-standalone.sh
@@ -49,8 +49,8 @@ export AR="$COMPILER_ROOT/bin/$TARGET-ar"
 export LD="$COMPILER_ROOT/bin/$TARGET-ld"
 export RANLIB="$COMPILER_ROOT/bin/$TARGET-ranlib"
 export STRIP="$COMPILER_ROOT/bin/$TARGET-strip"
-export CFLAGS="-I $COMPILER_ROOT/$TARGET/include -L $COMPILER_ROOT/$TARGET/lib"
-export LDFLAGS="-static $CFLAGS"
+export CFLAGS="-I $COMPILER_ROOT/$TARGET/include"
+export LDFLAGS="-static -Wl,--whole-archive -latomic -Wl,--no-whole-archive $CFLAGS"
 
 if [[ $CANDY_OS && $CANDY_ARCH ]];then
     BUILD_DIR="$CANDY_WORKSPACE/build/$CANDY_OS-$CANDY_ARCH"


### PR DESCRIPTION
编译纯静态二进制后运行时大概率出错，怀疑是 musl 多线程同时加密解密时出现问题。尝试过每次使用 ctx 时 new, 并在使用后 free, 问题就会出现在 EVP_CIPHER_CTX_free。修改为全局锁后这个问题没有再出现。

coredumpctl info

```txt
Module /usr/bin/candy-service without build-id.
Stack trace of thread 1930:
#0  0x0000000000b7ab36 __restore_sigs (/usr/bin/candy-service + 0x77ab36)
#1  0x00000000005d6173 evp_cipher_free_int (/usr/bin/candy-service + 0x1d6173)
#2  0x00000000005d61f7 EVP_CIPHER_free (/usr/bin/candy-service + 0x1d61f7)
#3  0x00000000005d05f8 EVP_CIPHER_CTX_reset (/usr/bin/candy-service + 0x1d05f8)
#4  0x00000000005bfa86 _ZN5candy4Peer7encryptERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE (/usr/bin/candy-service + 0x1bfa86)
#5  0x00000000005c0415 _ZN5candy4Peer20sendHeartbeatMessageEv (/usr/bin/candy-service + 0x1c0415)
#6  0x00000000005c162f _ZN5candy4Peer4tickEv (/usr/bin/candy-service + 0x1c162f)
#7  0x00000000005bbc59 _ZN5candy11PeerManager4tickEv (/usr/bin/candy-service + 0x1bbc59)
#8  0x00000000005bbe09 _ZNSt6thread11_State_implINS_8_InvokerISt5tupleIJZN5candy11PeerManager15startTickThreadEvEUlvE_EEEEE6_M_runEv (/usr/bin/candy-service + 0x1bbe09)
#9  0x0000000000b5326d execute_native_thread_routine (/usr/bin/candy-service + 0x75326d)
#10 0x0000000000b81599 start (/usr/bin/candy-service + 0x781599)
ELF object binary architecture: AMD x86-64
```