### PR TITLE
refactor: use nested Pimpl for Tun, drop std::any

### DIFF
--- a/candy/src/tun/linux.cc
+++ b/candy/src/tun/linux.cc
@@ -18,28 +18,9 @@
 
 namespace candy {
 
-class LinuxTun {
-public:
+struct Tun::Impl {
     int setName(const std::string &name) {
         this->name = name.empty() ? "candy" : "candy-" + name;
-        return 0;
-    }
-
-    int setIP(IP4 ip) {
-        this->ip = ip;
-        return 0;
-    }
-
-    IP4 getIP() {
-        return this->ip;
-    }
-
-    IP4 getMask() {
-        return this->mask;
-    }
-
-    int setMask(IP4 mask) {
-        this->mask = mask;
         return 0;
     }
 
@@ -49,7 +30,7 @@ public:
     }
 
     // Configure the interface and set up routing
-    int up() {
+    int up(IP4 ip, IP4 mask) {
         this->tunFd = open("/dev/net/tun", O_RDWR);
         if (this->tunFd < 0) {
             candy::logger().fatal(Poco::format("open /dev/net/tun failed: %s", strerror(errno)));
@@ -92,18 +73,18 @@ public:
         }
 
         // Set address
-        addr->sin_addr.s_addr = this->ip;
+        addr->sin_addr.s_addr = ip;
         if (ioctl(sockfd, SIOCSIFADDR, (caddr_t)&ifr) == -1) {
-            candy::logger().fatal(Poco::format("set ip address failed: ip %s", this->ip.toString()));
+            candy::logger().fatal(Poco::format("set ip address failed: ip %s", ip.toString()));
             close(sockfd);
             close(this->tunFd);
             return -1;
         }
 
         // Set mask
-        addr->sin_addr.s_addr = this->mask;
+        addr->sin_addr.s_addr = mask;
         if (ioctl(sockfd, SIOCSIFNETMASK, (caddr_t)&ifr) == -1) {
-            candy::logger().fatal(Poco::format("set mask failed: mask %s", this->mask.toString()));
+            candy::logger().fatal(Poco::format("set mask failed: mask %s", mask.toString()));
             close(sockfd);
             close(this->tunFd);
             return -1;
@@ -205,101 +186,42 @@ public:
 
 private:
     std::string name;
-    IP4 ip;
-    IP4 mask;
     int mtu;
-    int timeout;
     int tunFd;
 };
 
-} // namespace candy
-
-namespace candy {
-
 Tun::Tun() {
-    this->impl = std::make_shared<LinuxTun>();
+    this->impl = std::make_unique<Impl>();
 }
 
-Tun::~Tun() {
-    this->impl.reset();
-}
+Tun::~Tun() {}
 
 int Tun::setName(const std::string &name) {
-    std::shared_ptr<LinuxTun> tun;
-
-    tun = std::any_cast<std::shared_ptr<LinuxTun>>(this->impl);
-    tun->setName(name);
-    return 0;
-}
-
-int Tun::setAddress(const std::string &cidr) {
-    std::shared_ptr<LinuxTun> tun;
-    Address address;
-
-    if (address.fromCidr(cidr)) {
-        return -1;
-    }
-    candy::logger().information(Poco::format("client address: %s", address.toCidr()));
-    tun = std::any_cast<std::shared_ptr<LinuxTun>>(this->impl);
-    if (tun->setIP(address.Host())) {
-        return -1;
-    }
-    if (tun->setMask(address.Mask())) {
-        return -1;
-    }
-    this->tunAddress = cidr;
-    return 0;
-}
-
-IP4 Tun::getIP() {
-    std::shared_ptr<LinuxTun> tun;
-    tun = std::any_cast<std::shared_ptr<LinuxTun>>(this->impl);
-    return tun->getIP();
-}
-
-bool Tun::inTunNetwork(IP4 addr) const {
-    std::shared_ptr<LinuxTun> tun;
-    tun = std::any_cast<std::shared_ptr<LinuxTun>>(this->impl);
-    return (addr & tun->getMask()) == (tun->getIP() & tun->getMask());
+    return this->impl->setName(name);
 }
 
 int Tun::setMTU(int mtu) {
-    std::shared_ptr<LinuxTun> tun;
-    tun = std::any_cast<std::shared_ptr<LinuxTun>>(this->impl);
-    if (tun->setMTU(mtu)) {
-        return -1;
-    }
-    return 0;
+    return this->impl->setMTU(mtu);
 }
 
 int Tun::up() {
-    std::shared_ptr<LinuxTun> tun;
-    tun = std::any_cast<std::shared_ptr<LinuxTun>>(this->impl);
-    return tun->up();
+    return this->impl->up(this->ip, this->mask);
 }
 
 int Tun::down() {
-    std::shared_ptr<LinuxTun> tun;
-    tun = std::any_cast<std::shared_ptr<LinuxTun>>(this->impl);
-    return tun->down();
+    return this->impl->down();
 }
 
 int Tun::read(std::string &buffer) {
-    std::shared_ptr<LinuxTun> tun;
-    tun = std::any_cast<std::shared_ptr<LinuxTun>>(this->impl);
-    return tun->read(buffer);
+    return this->impl->read(buffer);
 }
 
 int Tun::write(const std::string &buffer) {
-    std::shared_ptr<LinuxTun> tun;
-    tun = std::any_cast<std::shared_ptr<LinuxTun>>(this->impl);
-    return tun->write(buffer);
+    return this->impl->write(buffer);
 }
 
 int Tun::setSysRtTable(IP4 dst, IP4 mask, IP4 nexthop) {
-    std::shared_ptr<LinuxTun> tun;
-    tun = std::any_cast<std::shared_ptr<LinuxTun>>(this->impl);
-    return tun->setSysRtTable(dst, mask, nexthop);
+    return this->impl->setSysRtTable(dst, mask, nexthop);
 }
 
 } // namespace candy

--- a/candy/src/tun/macos.cc
+++ b/candy/src/tun/macos.cc
@@ -27,28 +27,8 @@
 
 namespace candy {
 
-class MacTun {
-public:
+struct Tun::Impl {
     int setName(const std::string &name) {
-        this->name = name.empty() ? "candy" : "candy-" + name;
-        return 0;
-    }
-
-    int setIP(IP4 ip) {
-        this->ip = ip;
-        return 0;
-    }
-
-    IP4 getIP() {
-        return this->ip;
-    }
-
-    IP4 getMask() {
-        return this->mask;
-    }
-
-    int setMask(IP4 mask) {
-        this->mask = mask;
         return 0;
     }
 
@@ -57,7 +37,7 @@ public:
         return 0;
     }
 
-    int up() {
+    int up(IP4 ip, IP4 mask) {
         // Create the device; macOS does not allow custom device names (kernel-assigned)
         this->tunFd = socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL);
         if (this->tunFd < 0) {
@@ -129,19 +109,19 @@ public:
         strncpy(areq.ifra_name, ifname, IFNAMSIZ);
         ((struct sockaddr_in *)&areq.ifra_addr)->sin_family = AF_INET;
         ((struct sockaddr_in *)&areq.ifra_addr)->sin_len = sizeof(areq.ifra_addr);
-        ((struct sockaddr_in *)&areq.ifra_addr)->sin_addr.s_addr = this->ip;
+        ((struct sockaddr_in *)&areq.ifra_addr)->sin_addr.s_addr = ip;
 
         ((struct sockaddr_in *)&areq.ifra_mask)->sin_family = AF_INET;
         ((struct sockaddr_in *)&areq.ifra_mask)->sin_len = sizeof(areq.ifra_mask);
-        ((struct sockaddr_in *)&areq.ifra_mask)->sin_addr.s_addr = this->mask;
+        ((struct sockaddr_in *)&areq.ifra_mask)->sin_addr.s_addr = mask;
 
         ((struct sockaddr_in *)&areq.ifra_broadaddr)->sin_family = AF_INET;
         ((struct sockaddr_in *)&areq.ifra_broadaddr)->sin_len = sizeof(areq.ifra_broadaddr);
-        ((struct sockaddr_in *)&areq.ifra_broadaddr)->sin_addr.s_addr = (this->ip & this->mask);
+        ((struct sockaddr_in *)&areq.ifra_broadaddr)->sin_addr.s_addr = (ip & mask);
 
         if (ioctl(sockfd, SIOCAIFADDR, (void *)&areq) == -1) {
-            candy::logger().fatal(Poco::format("set ip mask failed: %s: ip %s mask %s", strerror(errno), this->ip.toString(),
-                                               this->mask.toString()));
+            candy::logger().fatal(
+                Poco::format("set ip mask failed: %s: ip %s mask %s", strerror(errno), ip.toString(), mask.toString()));
             close(sockfd);
             close(this->tunFd);
             return -1;
@@ -173,7 +153,7 @@ public:
         close(sockfd);
 
         // Set route
-        if (setSysRtTable(this->ip & this->mask, this->mask, this->ip)) {
+        if (setSysRtTable(ip & mask, mask, ip)) {
             close(this->tunFd);
             return -1;
         }
@@ -220,7 +200,8 @@ public:
         iov[0].iov_len = sizeof(this->packetinfo);
         iov[1].iov_base = (void *)buffer.data();
         iov[1].iov_len = buffer.size();
-        return ::writev(this->tunFd, iov, sizeof(iov) / sizeof(iov[0])) - sizeof(sizeof(this->packetinfo));
+        auto size = ::writev(this->tunFd, iov, sizeof(iov) / sizeof(iov[0]));
+        return size - sizeof(this->packetinfo);
     }
 
     int setSysRtTable(IP4 dst, IP4 mask, IP4 nexthop) {
@@ -258,104 +239,45 @@ public:
     }
 
 private:
-    std::string name;
     char ifname[IFNAMSIZ] = {0};
-    IP4 ip;
-    IP4 mask;
     int mtu;
-    int timeout;
     int tunFd;
 
     uint8_t packetinfo[4] = {0x00, 0x00, 0x00, 0x02};
 };
 
-} // namespace candy
-
-namespace candy {
-
 Tun::Tun() {
-    this->impl = std::make_shared<MacTun>();
+    this->impl = std::make_unique<Impl>();
 }
 
-Tun::~Tun() {
-    this->impl.reset();
-}
+Tun::~Tun() {}
 
 int Tun::setName(const std::string &name) {
-    std::shared_ptr<MacTun> tun;
-
-    tun = std::any_cast<std::shared_ptr<MacTun>>(this->impl);
-    tun->setName(name);
-    return 0;
-}
-
-int Tun::setAddress(const std::string &cidr) {
-    std::shared_ptr<MacTun> tun;
-    Address address;
-
-    if (address.fromCidr(cidr)) {
-        return -1;
-    }
-    candy::logger().information(Poco::format("client address: %s", address.toCidr()));
-    tun = std::any_cast<std::shared_ptr<MacTun>>(this->impl);
-    if (tun->setIP(address.Host())) {
-        return -1;
-    }
-    if (tun->setMask(address.Mask())) {
-        return -1;
-    }
-    return 0;
-}
-
-IP4 Tun::getIP() {
-    std::shared_ptr<MacTun> tun;
-    tun = std::any_cast<std::shared_ptr<MacTun>>(this->impl);
-    return tun->getIP();
-}
-
-bool Tun::inTunNetwork(IP4 addr) const {
-    std::shared_ptr<MacTun> tun;
-    tun = std::any_cast<std::shared_ptr<MacTun>>(this->impl);
-    return (addr & tun->getMask()) == (tun->getIP() & tun->getMask());
+    return this->impl->setName(name);
 }
 
 int Tun::setMTU(int mtu) {
-    std::shared_ptr<MacTun> tun;
-    tun = std::any_cast<std::shared_ptr<MacTun>>(this->impl);
-    if (tun->setMTU(mtu)) {
-        return -1;
-    }
-    return 0;
+    return this->impl->setMTU(mtu);
 }
 
 int Tun::up() {
-    std::shared_ptr<MacTun> tun;
-    tun = std::any_cast<std::shared_ptr<MacTun>>(this->impl);
-    return tun->up();
+    return this->impl->up(this->ip, this->mask);
 }
 
 int Tun::down() {
-    std::shared_ptr<MacTun> tun;
-    tun = std::any_cast<std::shared_ptr<MacTun>>(this->impl);
-    return tun->down();
+    return this->impl->down();
 }
 
 int Tun::read(std::string &buffer) {
-    std::shared_ptr<MacTun> tun;
-    tun = std::any_cast<std::shared_ptr<MacTun>>(this->impl);
-    return tun->read(buffer);
+    return this->impl->read(buffer);
 }
 
 int Tun::write(const std::string &buffer) {
-    std::shared_ptr<MacTun> tun;
-    tun = std::any_cast<std::shared_ptr<MacTun>>(this->impl);
-    return tun->write(buffer);
+    return this->impl->write(buffer);
 }
 
 int Tun::setSysRtTable(IP4 dst, IP4 mask, IP4 nexthop) {
-    std::shared_ptr<MacTun> tun;
-    tun = std::any_cast<std::shared_ptr<MacTun>>(this->impl);
-    return tun->setSysRtTable(dst, mask, nexthop);
+    return this->impl->setSysRtTable(dst, mask, nexthop);
 }
 
 } // namespace candy

--- a/candy/src/tun/tun.cc
+++ b/candy/src/tun/tun.cc
@@ -82,9 +82,9 @@ int Tun::handleTunDevice() {
         header->daddr = nextHop;
     }
 
-    if (!inTunNetwork(header->saddr) || !inTunNetwork(header->daddr)) {
-        candy::logger().warning(Poco::format("packet src=%s or dst=%s not in tun network, dropping",
-            header->saddr.toString(), header->daddr.toString()));
+    if (invalidSrcDst(*header)) {
+        candy::logger().debug(Poco::format("packet src=%s or dst=%s not in tun network, dropping", header->saddr.toString(),
+                                           header->daddr.toString()));
         return 0;
     }
 
@@ -179,6 +179,44 @@ int Tun::setSysRtTable(const SysRouteEntry &entry) {
     std::unique_lock lock(this->sysRtMutex);
     this->sysRtTable.push_back(entry);
     return setSysRtTable(entry.dst, entry.mask, entry.nexthop);
+}
+
+int Tun::setAddress(const std::string &cidr) {
+    Address address;
+
+    if (address.fromCidr(cidr)) {
+        return -1;
+    }
+    candy::logger().information(Poco::format("client address: %s", address.toCidr()));
+    this->ip = address.Host();
+    this->mask = address.Mask();
+    this->tunAddress = cidr;
+    return 0;
+}
+
+IP4 Tun::getIP() const {
+    return this->ip;
+}
+
+IP4 Tun::getMask() const {
+    return this->mask;
+}
+
+bool Tun::inTunNetwork(IP4 addr) const {
+    return (addr & this->mask) == (this->ip & this->mask);
+}
+
+bool Tun::invalidSrcDst(const IP4Header &header) const {
+    if (inTunNetwork(header.saddr) && inTunNetwork(header.daddr)) {
+        return false;
+    }
+    if (header.daddr == IP4("255.255.255.255")) {
+        return false;
+    }
+    if ((header.daddr & IP4("240.0.0.0")) == IP4("224.0.0.0")) {
+        return false;
+    }
+    return true;
 }
 
 Client &Tun::getClient() {

--- a/candy/src/tun/tun.h
+++ b/candy/src/tun/tun.h
@@ -4,8 +4,8 @@
 
 #include "core/message.h"
 #include "core/net.h"
-#include <any>
 #include <list>
+#include <memory>
 #include <shared_mutex>
 #include <string>
 #include <thread>
@@ -25,11 +25,13 @@ public:
     int run(Client *client);
     int wait();
 
-    IP4 getIP();
-    bool inTunNetwork(IP4 addr) const;
+    IP4 getIP() const;
+    IP4 getMask() const;
 
 private:
     int setAddress(const std::string &cidr);
+    bool inTunNetwork(IP4 addr) const;
+    bool invalidSrcDst(const IP4Header &header) const;
 
     // Process data from the TUN device
     int handleTunDevice();
@@ -58,7 +60,10 @@ private:
     std::list<SysRouteEntry> sysRtTable;
 
 private:
-    std::any impl;
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+    IP4 ip;
+    IP4 mask;
 
 private:
     Client &getClient();

--- a/candy/src/tun/unknown.cc
+++ b/candy/src/tun/unknown.cc
@@ -7,44 +7,68 @@
 
 namespace candy {
 
-Tun::Tun() {}
+struct Tun::Impl {
+    int setName(const std::string &name) {
+        return -1;
+    }
+
+    int setMTU(int mtu) {
+        return -1;
+    }
+
+    int up(IP4 ip, IP4 mask) {
+        return -1;
+    }
+
+    int down() {
+        return -1;
+    }
+
+    int read(std::string &buffer) {
+        return -1;
+    }
+
+    int write(const std::string &buffer) {
+        return -1;
+    }
+
+    int setSysRtTable(IP4 dst, IP4 mask, IP4 nexthop) {
+        return -1;
+    }
+};
+
+Tun::Tun() {
+    this->impl = std::make_unique<Impl>();
+}
 
 Tun::~Tun() {}
 
 int Tun::setName(const std::string &name) {
-    return -1;
-}
-
-int Tun::setAddress(const std::string &cidr) {
-    return -1;
+    return this->impl->setName(name);
 }
 
 int Tun::setMTU(int mtu) {
-    return -1;
+    return this->impl->setMTU(mtu);
 }
 
 int Tun::up() {
-    return -1;
+    return this->impl->up(this->ip, this->mask);
 }
 
 int Tun::down() {
-    return -1;
+    return this->impl->down();
 }
 
 int Tun::read(std::string &buffer) {
-    return -1;
+    return this->impl->read(buffer);
 }
 
 int Tun::write(const std::string &buffer) {
-    return -1;
-}
-
-bool Tun::inTunNetwork(IP4 addr) const {
-    return false;
+    return this->impl->write(buffer);
 }
 
 int Tun::setSysRtTable(IP4 dst, IP4 mask, IP4 nexthop) {
-    return -1;
+    return this->impl->setSysRtTable(dst, mask, nexthop);
 }
 
 } // namespace candy

--- a/candy/src/tun/windows.cc
+++ b/candy/src/tun/windows.cc
@@ -89,28 +89,9 @@ private:
     HMODULE wintun = NULL;
 };
 
-class WindowsTun {
-public:
+struct Tun::Impl {
     int setName(const std::string &name) {
         this->name = name.empty() ? "candy" : name;
-        return 0;
-    }
-
-    int setIP(IP4 ip) {
-        this->ip = ip;
-        return 0;
-    }
-
-    IP4 getIP() {
-        return this->ip;
-    }
-
-    uint32_t getPrefix() {
-        return this->prefix;
-    }
-
-    int setPrefix(uint32_t prefix) {
-        this->prefix = prefix;
         return 0;
     }
 
@@ -119,7 +100,7 @@ public:
         return 0;
     }
 
-    int up() {
+    int up(IP4 ip, IP4 mask) {
         if (!Holder::Ok()) {
             candy::logger().fatal("init wintun failed");
             return -1;
@@ -140,8 +121,8 @@ public:
         InitializeUnicastIpAddressEntry(&AddressRow);
         WintunGetAdapterLUID(this->adapter, &AddressRow.InterfaceLuid);
         AddressRow.Address.Ipv4.sin_family = AF_INET;
-        AddressRow.Address.Ipv4.sin_addr.S_un.S_addr = this->ip;
-        AddressRow.OnLinkPrefixLength = this->prefix;
+        AddressRow.Address.Ipv4.sin_addr.S_un.S_addr = ip;
+        AddressRow.OnLinkPrefixLength = mask.toPrefix();
         AddressRow.DadState = IpDadStatePreferred;
         Error = CreateUnicastIpAddressEntry(&AddressRow);
         if (Error != ERROR_SUCCESS) {
@@ -255,10 +236,7 @@ public:
 
 private:
     std::string name;
-    IP4 ip;
-    uint32_t prefix;
     int mtu;
-    int timeout;
     NET_IFINDEX ifindex;
     std::stack<MIB_IPFORWARDROW> routes;
 
@@ -266,95 +244,38 @@ private:
     WINTUN_SESSION_HANDLE session = NULL;
 };
 
-} // namespace candy
-
-namespace candy {
-
 Tun::Tun() {
-    this->impl = std::make_shared<WindowsTun>();
+    this->impl = std::make_unique<Impl>();
 }
 
-Tun::~Tun() {
-    this->impl.reset();
-}
+Tun::~Tun() {}
 
 int Tun::setName(const std::string &name) {
-    std::shared_ptr<WindowsTun> tun;
-
-    tun = std::any_cast<std::shared_ptr<WindowsTun>>(this->impl);
-    tun->setName(name);
-    return 0;
-}
-
-int Tun::setAddress(const std::string &cidr) {
-    std::shared_ptr<WindowsTun> tun;
-    Address address;
-
-    if (address.fromCidr(cidr)) {
-        return -1;
-    }
-    candy::logger().information(Poco::format("client address: %s", address.toCidr()));
-    tun = std::any_cast<std::shared_ptr<WindowsTun>>(this->impl);
-    if (tun->setIP(address.Host())) {
-        return -1;
-    }
-    if (tun->setPrefix(address.Mask().toPrefix())) {
-        return -1;
-    }
-    return 0;
-}
-
-IP4 Tun::getIP() {
-    std::shared_ptr<WindowsTun> tun;
-    tun = std::any_cast<std::shared_ptr<WindowsTun>>(this->impl);
-    return tun->getIP();
-}
-
-bool Tun::inTunNetwork(IP4 addr) const {
-    std::shared_ptr<WindowsTun> tun;
-    tun = std::any_cast<std::shared_ptr<WindowsTun>>(this->impl);
-    IP4 mask;
-    mask.fromPrefix(tun->getPrefix());
-    return (addr & mask) == (tun->getIP() & mask);
+    return this->impl->setName(name);
 }
 
 int Tun::setMTU(int mtu) {
-    std::shared_ptr<WindowsTun> tun;
-    tun = std::any_cast<std::shared_ptr<WindowsTun>>(this->impl);
-    if (tun->setMTU(mtu)) {
-        return -1;
-    }
-    return 0;
+    return this->impl->setMTU(mtu);
 }
 
 int Tun::up() {
-    std::shared_ptr<WindowsTun> tun;
-    tun = std::any_cast<std::shared_ptr<WindowsTun>>(this->impl);
-    return tun->up();
+    return this->impl->up(this->ip, this->mask);
 }
 
 int Tun::down() {
-    std::shared_ptr<WindowsTun> tun;
-    tun = std::any_cast<std::shared_ptr<WindowsTun>>(this->impl);
-    return tun->down();
+    return this->impl->down();
 }
 
 int Tun::read(std::string &buffer) {
-    std::shared_ptr<WindowsTun> tun;
-    tun = std::any_cast<std::shared_ptr<WindowsTun>>(this->impl);
-    return tun->read(buffer);
+    return this->impl->read(buffer);
 }
 
 int Tun::write(const std::string &buffer) {
-    std::shared_ptr<WindowsTun> tun;
-    tun = std::any_cast<std::shared_ptr<WindowsTun>>(this->impl);
-    return tun->write(buffer);
+    return this->impl->write(buffer);
 }
 
 int Tun::setSysRtTable(IP4 dst, IP4 mask, IP4 nexthop) {
-    std::shared_ptr<WindowsTun> tun;
-    tun = std::any_cast<std::shared_ptr<WindowsTun>>(this->impl);
-    return tun->setSysRtTable(dst, mask, nexthop);
+    return this->impl->setSysRtTable(dst, mask, nexthop);
 }
 
 } // namespace candy


### PR DESCRIPTION
- Centralize inTunNetwork() in platform-agnostic tun.cc using getIP()/getMask()
- Replace std::any with unique_ptr<Impl>; platform tun classes become Tun::Impl
- Keep ip/mask state in Tun, up() now takes (IP4 ip, IP4 mask)
- Rename shouldDrop() to invalidSrcDst(), allow broadcast/multicast
- Remove dead members (timeout, macos name)